### PR TITLE
Fix builds on newer GCC 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EXT=
 endif
 
 main: $(BIN_DIR)
-	gcc -Os -s src/*.c -o $(BIN_DIR)/flot$(EXT)
+	gcc -fcommon -Os -s src/*.c -o $(BIN_DIR)/flot$(EXT)
 
 clean:
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
I was getting build errors, and a quick search online found this fix, and I figured it was worth committing back. 
https://bugzilla.redhat.com/show_bug.cgi?id=1869902#c1